### PR TITLE
Add fault card for ESX1 #9

### DIFF
--- a/docs/fault-cards/FC-ESX1-0009.md
+++ b/docs/fault-cards/FC-ESX1-0009.md
@@ -1,0 +1,26 @@
+# FC-ESX1-0009
+
+- **Exact code:** ESX1 #9
+- **Severity type:** DISAGREEMENT
+- **Affected modules:** MOD-ESX1
+- **Sensor inputs:** SEN-A2B-LOOP, SEN-INTERLOCK-CHAIN
+- **Confidence window:** CONDITIONAL
+
+## Definition
+
+- **Plain:** Digital safety input plausibility failure on ESX1; system cannot trust one safety input.
+- **Technical:** ESX1 reports invalid/missing/implausible digital input signal on one channel.
+
+## Protects Against
+
+- False stability or false capacity due to untrusted safety state.
+
+## First Checks
+
+1. Confirm ACTIVE vs HISTORY.
+2. Note which motions are inhibited.
+3. Check if fault appears during a specific motion.
+
+## Stop-Work Triggers
+
+- Any suspended load with active ESX disagreement.


### PR DESCRIPTION
### Motivation
- Introduce a documented fault card for the ESX1 digital input plausibility disagreement to capture diagnostic and safety guidance.
- Provide explicit first-checks and stop-work triggers to prevent unsafe operations when ESX1 reports an implausible or missing digital input.
- Ensure the repository contains structured operational guidance for faults affecting `MOD-ESX1`.

### Description
- Add `docs/fault-cards/FC-ESX1-0009.md` containing the exact code, severity type, affected modules, sensor inputs, confidence window, plain and technical definitions, protections, first checks, and stop-work triggers.
- Create the `docs/fault-cards/` directory to house the new fault card and future fault documentation.

### Testing
- No automated tests were executed because this is a documentation-only change.
- Existing CI and unit tests were not modified and are expected to be unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549eabaeb483339f9ce1cb8ccc9b8b)